### PR TITLE
Fixed typo in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const fs = require("fs");
 const file = fs.createWriteStream(__dirname + "/test.webm");
 
 async function test() {
-	const browser = await slaunch({
+	const browser = await launch({
 		defaultViewport: {
 			width: 1920,
 			height: 1080,


### PR DESCRIPTION
I just simply adjust the example in the README.md to a working one.