### PR TITLE
Fix extension loading

### DIFF
--- a/src/PuppeteerStream.ts
+++ b/src/PuppeteerStream.ts
@@ -37,13 +37,13 @@ export async function launch(opts: LaunchOptions & BrowserOptions & ChromeArgOpt
 	let loadExtensionExcept = false;
 	let whitelisted = false;
 
-	opts.args.map((x) => {
+	opts.args = opts.args.map((x) => {
 		if (x.includes("--load-extension=")) {
 			loadExtension = true;
 			return x + "," + extensionPath;
 		} else if (x.includes("--disable-extensions-except=")) {
 			loadExtensionExcept = true;
-			return x + "," + extensionPath;
+			return "--disable-extensions-except=" + extensionPath + "," + x.split("=")[1];
 		} else if (x.includes("--whitelisted-extension-id")) {
 			whitelisted = true;
 			return x + "," + extensionId;


### PR DESCRIPTION
**Issue**
When using with Chrome Browser and Chrome Extension via --disable-extensions-except, page() will be undefined, because browser.targets() returns only the first Chrome Extension in an array. So targets.find() will fail then and will raise an error on extensionTarget.page()

**Test Code**
```
const { launch, getStream } = require("puppeteer-stream");

(async () => {
  const browser = await launch({
        executablePath: "C:/Program Files/Google/Chrome/Application/chrome.exe",
        headless: false,
        args: [
            "--disable-extensions-except=C:/Users/Me/AppData/Local/Google/Chrome/User Data/Default/Extensions/randomextensionid/1.1.0"
        ]
  });
})();
```

**Fix**
Make sure, Video Recorder will be the first Chrome Extension and opts.args.map will be written back to variable


Would be nice if you create a new release for that and also push it to npm
Thanks for your effort, really nice to have a plugin like this one