### PR TITLE
updated puppeteer dependency

### DIFF
--- a/package.json.bak
+++ b/package.json.bak
@@ -21,7 +21,7 @@
 	},
 	"license": "ISC",
 	"dependencies": {
-		"puppeteer": "^11.0.0"
+		"puppeteer": "^7.1.0"
 	},
 	"devDependencies": {
 		"@types/node": "^14.14.14",


### PR DESCRIPTION
just updated the dep, so it can be easily installed under m1 macs